### PR TITLE
Moving headerFontSize to headerTitle due to lousy css inheritance

### DIFF
--- a/lib/Header.jsx
+++ b/lib/Header.jsx
@@ -10,7 +10,6 @@ const Header = styled.div`
   height: 56px;
   justify-content: space-between;
   padding: 0 10px;
-  font-size:${({ theme }) => theme.headerFontSize};
 `;
 
 Header.defaultProps = {

--- a/lib/HeaderTitle.jsx
+++ b/lib/HeaderTitle.jsx
@@ -1,7 +1,13 @@
 import styled from 'styled-components';
+import defaultTheme from './theme';
 
 const HeaderTitle = styled.h2`
   margin: 0;
+  font-size:${({ theme }) => theme.headerFontSize};
 `;
+
+HeaderTitle.defaultProps = {
+  theme: defaultTheme,
+};
 
 export default HeaderTitle;


### PR DESCRIPTION
Since inheritance is the weakest way to style an element it was being overriden by very basic bootstrap css. By moving it into the headerTitle at least the element has strong specificity when applying other css styles. 

Also opens the door for specific style of the header with theming.