### PR TITLE
Add bubbleOptionStyle prop

### DIFF
--- a/lib/ChatBot.jsx
+++ b/lib/ChatBot.jsx
@@ -428,7 +428,14 @@ class ChatBot extends Component {
 
   renderStep(step, index) {
     const { renderedSteps } = this.state;
-    const { avatarStyle, bubbleStyle, customStyle, hideBotAvatar, hideUserAvatar } = this.props;
+    const {
+      avatarStyle,
+      bubbleStyle,
+      bubbleOptionStyle,
+      customStyle,
+      hideBotAvatar,
+      hideUserAvatar,
+    } = this.props;
     const { options, component, asMessage } = step;
     const steps = this.generateRenderedStepsById();
     const previousStep = index > 0 ? renderedSteps[index - 1] : {};
@@ -452,7 +459,7 @@ class ChatBot extends Component {
           key={index}
           step={step}
           triggerNextStep={this.triggerNextStep}
-          bubbleStyle={bubbleStyle}
+          bubbleOptionStyle={bubbleOptionStyle}
         />
       );
     }
@@ -584,6 +591,7 @@ ChatBot.propTypes = {
   botAvatar: PropTypes.string,
   botDelay: PropTypes.number,
   bubbleStyle: PropTypes.object,
+  bubbleOptionStyle: PropTypes.object,
   cache: PropTypes.bool,
   cacheName: PropTypes.string,
   className: PropTypes.string,
@@ -618,6 +626,7 @@ ChatBot.defaultProps = {
   avatarStyle: {},
   botDelay: 1000,
   bubbleStyle: {},
+  bubbleOptionStyle: {},
   cache: false,
   cacheName: 'rsc_cache',
   className: '',

--- a/lib/steps/options/OptionsStep.jsx
+++ b/lib/steps/options/OptionsStep.jsx
@@ -20,7 +20,7 @@ class OptionsStep extends Component {
   }
 
   renderOption(option) {
-    const { bubbleStyle } = this.props;
+    const { bubbleOptionStyle } = this.props;
     const { user } = this.props.step;
     const { value, label } = option;
 
@@ -31,7 +31,7 @@ class OptionsStep extends Component {
       >
         <OptionElement
           className="rsc-os-option-element"
-          style={bubbleStyle}
+          style={bubbleOptionStyle}
           user={user}
           onClick={() => this.onOptionClick({ value })}
         >
@@ -57,7 +57,7 @@ class OptionsStep extends Component {
 OptionsStep.propTypes = {
   step: PropTypes.object.isRequired,
   triggerNextStep: PropTypes.func.isRequired,
-  bubbleStyle: PropTypes.object.isRequired,
+  bubbleOptionStyle: PropTypes.object.isRequired,
 };
 
 export default OptionsStep;


### PR DESCRIPTION
Currently the `bubbleStyle` prop, styles both the chatbot and options bubbles.

### What it should do?
Add different styling to the option buttons

### Why it is useful
Gives greater control to customise the styling of the chatbot

### How users should use it
Add the prop `bubbleOptionStyle` to override the option bubble element