### PR TITLE
Fixes dist file not working on server-side

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -13,6 +13,7 @@ module.exports = {
     publicPath: 'dist/',
     library: 'ReactSimpleChatbot',
     libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
When packaging a library as UMD, webpack inserts a reference to `window` which causes errors on Node when server-side rendering a component that imports this library.

Tested by building locally and linking, unsure if any tests can be written for this.

Applies this fix: https://github.com/webpack/webpack/issues/6784#issuecomment-375941431

See https://github.com/webpack/webpack/pull/8625 for cause