### PR TITLE
Use object keys instead of values to support more browsers.

### DIFF
--- a/lib/steps_components/options/OptionsStep.jsx
+++ b/lib/steps_components/options/OptionsStep.jsx
@@ -38,7 +38,9 @@ class OptionsStep extends Component {
     return (
       <OptionsStepContainer className="rsc-os">
         <Options className="rsc-os-options">
-          {Object.values(options).map(this.renderOption)}
+          {Object.keys(options).map(key => {
+            return options[key];
+          }).map(this.renderOption)}
         </Options>
       </OptionsStepContainer>
     );

--- a/lib/steps_components/options/OptionsStep.jsx
+++ b/lib/steps_components/options/OptionsStep.jsx
@@ -38,9 +38,7 @@ class OptionsStep extends Component {
     return (
       <OptionsStepContainer className="rsc-os">
         <Options className="rsc-os-options">
-          {Object.keys(options).map(key => {
-            return options[key];
-          }).map(this.renderOption)}
+          {Object.keys(options).map(key => options[key]).map(this.renderOption)}
         </Options>
       </OptionsStepContainer>
     );


### PR DESCRIPTION
Object.values is not support iOS < 10.3 and Edge < 14
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values

This PR fixes that