### PR TITLE
Added babel transform for Object.assign

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,7 @@ const presets = ['@babel/env', '@babel/preset-react'];
 const plugins = [
   '@babel/plugin-transform-arrow-functions',
   '@babel/plugin-proposal-class-properties',
+  '@babel/plugin-transform-object-assign'
 ];
 
 module.exports = { presets, plugins };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-chatbot",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1134,6 +1134,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
       "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz",
+      "integrity": "sha512-nmE55cZBPFgUktbF2OuoZgPRadfxosLOpSgzEPYotKSls9J4pEPcembi8r78RU37Rph6UApCpNmsQA4QMWK9Ng==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-transform-arrow-functions": "^7.0.0",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,14 +24,7 @@ module.exports = {
         test: /\.jsx?$/,
         exclude: /(node_modules|bower_components)/,
         use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env'],
-            plugins: [
-              '@babel/plugin-transform-arrow-functions',
-              '@babel/plugin-proposal-class-properties',
-            ],
-          },
+          loader: 'babel-loader'
         },
       },
     ],

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -34,14 +34,7 @@ module.exports = {
         test: /\.jsx?$/,
         exclude: /(node_modules|bower_components)/,
         use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env'],
-            plugins: [
-              '@babel/plugin-transform-arrow-functions',
-              '@babel/plugin-proposal-class-properties',
-            ],
-          },
+          loader: 'babel-loader'
         },
       },
     ],


### PR DESCRIPTION
Object.assign is missing in IE 11

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility