### PR TITLE
Add documentation for metadata.speak

### DIFF
--- a/app/components/docs/pages/examples/SpeechSynthesis.js
+++ b/app/components/docs/pages/examples/SpeechSynthesis.js
@@ -4,7 +4,7 @@ import ChatBot from 'react-simple-chatbot';
 const $ = require('jquery');
 
 const exampleCode =
-`<ChatBot
+  `<ChatBot
   headerTitle="Speech Synthesis"
   speechSynthesis={{ enable: true, lang: 'en' }}
   steps={[
@@ -21,6 +21,20 @@ const exampleCode =
     {
       id: '3',
       message: 'Hi {previousValue}, nice to meet you!',
+      metadata: {
+        speak: 'Hi {previousValue}. Note that I am saying something different then the messsage text'
+      },
+      trigger: '4',
+    },
+    {
+      id: '4',
+      component: (
+        <div>This is a custom component </div>
+      ),
+      delay: 4000,
+      metadata: {
+        speak: 'I can also say something about a custom component'
+      },
       end: true,
     },
   ]}
@@ -54,11 +68,30 @@ class SpeechRecognition extends Component {
             {
               id: '3',
               message: 'Hi {previousValue}, nice to meet you!',
+              metadata: {
+                speak: 'Hi {previousValue}. Note that I am saying something different then the messsage text'
+              },
+              trigger: '4',
+            },
+            {
+              id: '4',
+              component: (
+                <div>This is an custom component </div>
+              ),
+              delay: 4000,
+              metadata: {
+                speak: 'I can also say something about a custom component'
+              },
               end: true,
             },
           ]}
         />
-        <h3 style={{ marginTop: 20 }}>Code</h3>
+        <h3 style={{ marginTop: 20 }}>Note</h3>
+        <p>
+          Adding speak to metadata will make the chatbot say that custom phrase insted of the message.<br />
+          For custom components metadata.speak is the only way to get the chatbot to speak.
+        </p>
+        <h3 >Code</h3>
         <pre>
           <code className="jsx">
             {exampleCode}

--- a/app/components/docs/pages/reference/Steps.jsx
+++ b/app/components/docs/pages/reference/Steps.jsx
@@ -6,7 +6,7 @@ const $ = require('jquery');
 require('./Steps.css');
 
 const textStepCode =
-`{
+  `{
   id: '1',
   message: 'Hello World',
   trigger: '2',
@@ -24,7 +24,7 @@ const textStepCode =
 `;
 
 const userStepCode =
-`{
+  `{
   id: '1',
   user: true,
   end: true,
@@ -32,7 +32,7 @@ const userStepCode =
 `;
 
 const optionsStepCode =
-`{
+  `{
   id: '1',
   options: [
     { value: 1, label: 'Number 1', trigger: '3' },
@@ -43,7 +43,7 @@ const optionsStepCode =
 `;
 
 const updateStepCode =
-`{
+  `{
   id: '1',
   update: '2',
   trigger: '3',
@@ -51,7 +51,7 @@ const updateStepCode =
 `;
 
 const customStepCode =
-`{
+  `{
   id: '1',
   component: <CustomComponent />
   trigger: '2'
@@ -121,7 +121,7 @@ const sections = [
         name: 'metadata',
         type: 'Object',
         required: 'false',
-        description: 'Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format',
+        description: 'Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. The metadata property "speak" enables custom phrases to be spoken when using speech synthesis. {speak: "Custom phrase"}',
       },
     ],
   },
@@ -283,7 +283,7 @@ const sections = [
         name: 'metadata',
         type: 'Object',
         required: 'false',
-        description: 'Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format',
+        description: 'Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. The metadata property "speak" enables phrases to be spoken when using speech synthesis. This is especially useful from an accessibility perspective as it enables descriptions for a component.',
       },
     ],
   },


### PR DESCRIPTION
Added documentation for undocumented API metadata.speak property.

This will potentially improve accessibility as it gives the possibility to add extra information using speech synthesis.